### PR TITLE
feat: 모든 페이지의 테마를 랜딩페이지와 통일

### DIFF
--- a/src/components/game/ConnectionStatus.tsx
+++ b/src/components/game/ConnectionStatus.tsx
@@ -7,18 +7,18 @@ const ConnectionStatus: React.FC = () => {
   return (
     <div className="absolute top-4 left-4 z-10">
       <div
-        className={`flex items-center space-x-2 px-3 py-2 rounded-lg text-sm font-medium ${
+        className={`flex items-center space-x-2 px-4 py-2 rounded-full text-sm font-bold border-2 ${
           isConnected
-            ? 'bg-green-100 text-green-800 border border-green-200'
-            : 'bg-red-100 text-red-800 border border-red-200'
+            ? 'bg-green-500 text-white border-green-300 shadow-lg'
+            : 'bg-red-500 text-white border-red-300 shadow-lg'
         }`}
       >
         <div
-          className={`w-2 h-2 rounded-full ${
-            isConnected ? 'bg-green-500' : 'bg-red-500'
+          className={`w-3 h-3 rounded-full ${
+            isConnected ? 'bg-green-300' : 'bg-red-300'
           }`}
         />
-        <span>{isConnected ? '백엔드 연결됨' : '백엔드 연결 안됨'}</span>
+        <span>{isConnected ? '🟢 백엔드 연결됨' : '🔴 백엔드 연결 안됨'}</span>
       </div>
     </div>
   );

--- a/src/components/game/GameHeader.tsx
+++ b/src/components/game/GameHeader.tsx
@@ -35,15 +35,15 @@ const GameHeader: React.FC = () => {
       <div className="absolute top-2 right-2 sm:top-4 sm:right-4 flex space-x-1 sm:space-x-2 z-10">
         <button
           onClick={handleSave}
-          className="px-2 py-1 sm:px-4 sm:py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors text-xs sm:text-sm"
+          className="px-2 py-1 sm:px-4 sm:py-2 bg-yellow-500 text-black rounded-lg hover:bg-yellow-600 transition-colors text-xs sm:text-sm font-bold border-2 border-yellow-300"
         >
-          저장
+          💾 저장
         </button>
         <button
           onClick={handleMainMenu}
-          className="px-2 py-1 sm:px-4 sm:py-2 bg-gray-600 text-white rounded-lg hover:bg-gray-700 transition-colors text-xs sm:text-sm"
+          className="px-2 py-1 sm:px-4 sm:py-2 bg-black text-yellow-400 rounded-lg hover:bg-gray-800 transition-colors text-xs sm:text-sm font-bold border-2 border-yellow-400"
         >
-          메뉴
+          ⚙️ 메뉴
         </button>
       </div>
 
@@ -72,19 +72,19 @@ const GameHeader: React.FC = () => {
         <div className="space-y-4">
           <button
             onClick={handleSave}
-            className="w-full text-left p-3 hover:bg-gray-100 rounded-lg transition-colors"
+            className="w-full text-left p-3 hover:bg-yellow-100 rounded-lg transition-colors border-l-4 border-yellow-500 pl-4"
           >
             💾 게임 저장
           </button>
           <button
             onClick={handleQuitGame}
-            className="w-full text-left p-3 hover:bg-gray-100 rounded-lg transition-colors text-red-600"
+            className="w-full text-left p-3 hover:bg-red-100 rounded-lg transition-colors text-red-600 border-l-4 border-red-500 pl-4"
           >
             🚪 게임 종료
           </button>
           <button
             onClick={handleLogout}
-            className="w-full text-left p-3 hover:bg-gray-100 rounded-lg transition-colors text-red-600"
+            className="w-full text-left p-3 hover:bg-red-100 rounded-lg transition-colors text-red-600 border-l-4 border-red-500 pl-4"
           >
             🔓 로그아웃
           </button>

--- a/src/components/game/GameLayout.tsx
+++ b/src/components/game/GameLayout.tsx
@@ -10,7 +10,7 @@ interface GameLayoutProps {
 
 const GameLayout: React.FC<GameLayoutProps> = ({ children }) => {
   return (
-    <div className="relative flex flex-col lg:flex-row h-screen bg-gray-100">
+    <div className="relative flex flex-col lg:flex-row h-screen bg-black">
       {/* 게임 헤더 */}
       <GameHeader />
 
@@ -18,12 +18,12 @@ const GameLayout: React.FC<GameLayoutProps> = ({ children }) => {
       <ConnectionStatus />
 
       {/* 왼쪽 패널 - 대화 및 상호작용 영역 */}
-      <div className="flex-1 flex flex-col min-h-0">
+      <div className="flex-1 flex flex-col min-h-0 bg-gradient-to-br from-yellow-500 to-yellow-600">
         <GameDialog />
       </div>
 
       {/* 오른쪽 패널 - 상태 및 정보 영역 */}
-      <div className="w-full lg:w-80 bg-white shadow-lg order-first lg:order-last">
+      <div className="w-full lg:w-80 bg-black shadow-2xl order-first lg:order-last border-l-4 border-yellow-400">
         <GameStatus />
       </div>
     </div>

--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -105,66 +105,87 @@ export default function Home() {
   };
 
   return (
-    <div className="relative min-h-screen">
-      {/* 로그아웃 버튼 */}
-      <div className="absolute top-4 right-4 z-10">
-        <button
-          onClick={() => {
-            logout();
-            navigate('/');
-          }}
-          className="px-3 py-2 sm:px-4 sm:py-2 bg-red-600 text-white rounded-lg hover:bg-red-700 transition-colors text-sm sm:text-base"
-        >
-          로그아웃
-        </button>
+    <div className="min-h-screen bg-black font-sans text-white">
+      {/* Top Section */}
+      <div className="relative bg-yellow-500 text-black">
+        <div className="max-w-6xl mx-auto px-2 py-20 flex flex-col items-center">
+          <div className="text-center">
+            <h1 id="title" className="text-6xl font-extrabold text-white">
+              의성 2077: 고운사 수호자
+            </h1>
+            <h2 id="title" className="text-5xl font-extrabold text-yellow-950">
+              모험의 시작
+            </h2>
+            <p id="text" className="text-1xl mt-2 text-white">
+              {getUserName()}님, 고운사를 수호하는 모험을 떠나보세요!
+            </p>
+          </div>
+        </div>
       </div>
 
       {/* 서버 연결 상태 표시 */}
-      <div className="absolute top-4 left-1/2 transform -translate-x-1/2 z-10">
+      <div className="bg-black py-8 text-center">
         <div
-          className={`px-3 py-2 rounded-lg text-sm font-medium ${
+          className={`inline-block px-6 py-3 rounded-full text-lg font-medium ${
             serverHealth
-              ? 'bg-green-100 text-green-800 border border-green-300'
-              : 'bg-red-100 text-red-800 border border-red-300'
+              ? 'bg-green-500 text-white border-2 border-green-300'
+              : 'bg-red-500 text-white border-2 border-red-300'
           }`}
         >
           {serverHealth ? '🟢 백엔드 연결됨' : '🔴 백엔드 연결 안됨'}
         </div>
       </div>
 
-      <h1 className="text-2xl sm:text-3xl md:text-4xl absolute top-4 left-4 font-bold">
-        TEXT ADVENTURE
-      </h1>
-
-      <div className="flex flex-col items-center justify-center min-h-screen px-4">
-        <h2 className="text-3xl sm:text-5xl md:text-7xl mb-8 md:mb-14 text-center leading-tight">
-          모험을 떠나보아요{' '}
-          <span className="text-4xl sm:text-6xl md:text-8xl text-purple-500 block sm:inline">
-            {getUserName()}
-          </span>
-          님!
-        </h2>
-
-        <div className="space-y-4 sm:space-y-6 md:space-y-8 w-full max-w-md">
-          <button
-            onClick={() => setIsModalOpen(true)}
-            className="w-full sm:min-w-96 shadow-lg rounded-full flex text-xl sm:text-3xl md:text-4xl items-center justify-center py-3 px-6 border border-gray-400 bg-white hover:bg-gray-50 transition-all duration-200"
-          >
-            새로시작
-          </button>
-          <button
-            onClick={() => {
-              if (hasSavedGame()) {
-                setIsContinueModalOpen(true);
-              } else {
-                alert('저장된 게임이 없습니다.');
-              }
-            }}
-            className="w-full sm:min-w-96 shadow-lg rounded-full flex text-xl sm:text-3xl md:text-4xl items-center justify-center py-3 px-6 border border-gray-400 bg-white hover:bg-gray-50 transition-all duration-200"
-          >
-            이어서 하기
-          </button>
+      {/* 게임 선택 섹션 */}
+      <div className="bg-yellow-500 py-16">
+        <div className="max-w-4xl mx-auto px-4">
+          <h2 id="title" className="text-4xl font-bold text-black text-center mb-12">
+            게임을 선택하세요
+          </h2>
+          
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
+            <button
+              onClick={() => setIsModalOpen(true)}
+              className="bg-black text-white p-8 rounded-2xl shadow-2xl hover:bg-gray-800 transition-all duration-300 transform hover:scale-105 border-4 border-yellow-300"
+            >
+              <div className="text-center">
+                <div className="text-6xl mb-4">🎮</div>
+                <h3 className="text-2xl font-bold mb-2">새로 시작</h3>
+                <p className="text-yellow-300">새로운 모험을 시작합니다</p>
+              </div>
+            </button>
+            
+            <button
+              onClick={() => {
+                if (hasSavedGame()) {
+                  setIsContinueModalOpen(true);
+                } else {
+                  alert('저장된 게임이 없습니다.');
+                }
+              }}
+              className="bg-black text-white p-8 rounded-2xl shadow-2xl hover:bg-gray-800 transition-all duration-300 transform hover:scale-105 border-4 border-yellow-300"
+            >
+              <div className="text-center">
+                <div className="text-6xl mb-4">📚</div>
+                <h3 className="text-2xl font-bold mb-2">이어서 하기</h3>
+                <p className="text-yellow-300">저장된 게임을 불러옵니다</p>
+              </div>
+            </button>
+          </div>
         </div>
+      </div>
+
+      {/* 로그아웃 버튼 */}
+      <div className="bg-black py-8 text-center">
+        <button
+          onClick={() => {
+            logout();
+            navigate('/');
+          }}
+          className="bg-red-600 hover:bg-red-700 text-white font-bold py-3 px-8 rounded-full transition-colors border-2 border-red-400"
+        >
+          로그아웃
+        </button>
       </div>
 
       {/* 새 게임 시작 모달 */}

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -69,45 +69,77 @@ export default function Login() {
   };
 
   return (
-    <div
-      className={`flex flex-col justify-center items-center min-h-screen text-center px-4 transition-colors duration-200 ${
-        theme === 'dark' ? 'bg-black text-white' : 'bg-white text-black'
-      }`}
-    >
+    <div className="min-h-screen bg-black font-sans text-white">
       {/* 테마 토글 버튼 */}
       <div className="absolute top-4 right-4 z-10">
         <ThemeToggle />
       </div>
 
-      <div className="max-w-4xl mx-auto w-full">
-        <p className="text-2xl sm:text-4xl md:text-6xl mb-5 px-4 leading-tight">
-          인공지능을 통해서 즐기는
-        </p>
-        <h1 className="text-4xl sm:text-6xl md:text-7xl text-[#6D00C1] mb-6 md:mb-10 px-4 font-bold">
-          TEXT ADVENTURE
-        </h1>
-
-        {/* 에러 메시지 */}
-        {error && (
-          <div className="mb-6 p-4 bg-red-100 border border-red-400 text-red-700 rounded-lg max-w-md mx-auto text-sm sm:text-base">
-            {error}
+      {/* Top Section */}
+      <div className="relative bg-yellow-500 text-black">
+        <div className="max-w-6xl mx-auto px-2 py-20 flex flex-col items-center">
+          <div className="text-center">
+            <h1 id="title" className="text-6xl font-extrabold text-white">
+              의성 2077: 고운사 수호자
+            </h1>
+            <h2 id="title" className="text-5xl font-extrabold text-yellow-950">
+              로그인
+            </h2>
+            <p id="text" className="text-1xl mt-2 text-white">
+              게임을 시작하려면 로그인해주세요
+            </p>
           </div>
-        )}
-
-        {/* 로딩 상태 */}
-        {isLoading && (
-          <div className="mb-6 flex items-center justify-center">
-            <div className="animate-spin rounded-full h-6 w-6 sm:h-8 sm:w-8 border-b-2 border-purple-600"></div>
-            <span className="ml-3 text-base sm:text-lg">로그인 중...</span>
-          </div>
-        )}
-
-        <div className="px-4">
-          <GoogleLogin
-            onSuccess={handleGoogleSuccess}
-            onError={handleGoogleError}
-          />
         </div>
+      </div>
+
+      {/* 로그인 섹션 */}
+      <div className="bg-black py-16">
+        <div className="max-w-4xl mx-auto px-4 text-center">
+          <div className="bg-yellow-500 text-black p-12 rounded-2xl shadow-2xl max-w-2xl mx-auto">
+            <h3 id="title" className="text-3xl font-bold mb-8">
+              인공지능을 통해서 즐기는
+            </h3>
+            <h4 id="title" className="text-4xl font-bold text-yellow-950 mb-8">
+              TEXT ADVENTURE
+            </h4>
+
+            {/* 에러 메시지 */}
+            {error && (
+              <div className="mb-6 p-4 bg-red-100 border border-red-400 text-red-700 rounded-lg max-w-md mx-auto text-sm">
+                {error}
+              </div>
+            )}
+
+            {/* 로딩 상태 */}
+            {isLoading && (
+              <div className="mb-6 flex items-center justify-center">
+                <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-black"></div>
+                <span className="ml-3 text-lg text-black">로그인 중...</span>
+              </div>
+            )}
+
+            <div className="mb-8">
+              <GoogleLogin
+                onSuccess={handleGoogleSuccess}
+                onError={handleGoogleError}
+              />
+            </div>
+
+            <p className="text-yellow-950 text-sm">
+              Google 계정으로 간편하게 로그인하세요
+            </p>
+          </div>
+        </div>
+      </div>
+
+      {/* 뒤로가기 버튼 */}
+      <div className="bg-black py-8 text-center">
+        <button
+          onClick={() => navigate('/')}
+          className="bg-gray-600 hover:bg-gray-700 text-white font-bold py-3 px-8 rounded-full transition-colors border-2 border-gray-400"
+        >
+          ← 랜딩페이지로 돌아가기
+        </button>
       </div>
     </div>
   );


### PR DESCRIPTION
- 홈페이지: 랜딩페이지와 동일한 스타일로 수정
  - 노란색 헤더 + 검은색 배경
  - 게임 선택 카드 디자인 개선
  - 서버 연결 상태 표시 스타일 통일

- 로그인페이지: 랜딩페이지와 동일한 스타일로 수정
  - 노란색 헤더 + 검은색 배경
  - 노란색 로그인 박스 디자인
  - 뒤로가기 버튼 추가

- 게임페이지: 테마에 맞게 스타일 수정
  - 검은색 배경 + 노란색 그라데이션 대화 영역
  - 게임 헤더 버튼 스타일 통일
  - 연결 상태 표시 스타일 개선

- 전체적으로 일관된 색상 체계와 디자인 언어 적용